### PR TITLE
Add multi-platform docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -44,3 +50,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
-            oidfed/lighthouse
-          # generate Docker tags based on the following events/attributes
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -37,12 +35,13 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       -
-        name: Login to DockerHub
+        name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Hello, 

I am one of the developers from the Australian Access Federation (AAF). We are currently in the process of deploying lighthouse to our k8s cluster which are running on arm64 nodes. I've updated the docker GitHub action to build for multiple platforms. 

I have tested this by [building the image using the updated action ](https://github.com/waldofouche/lighthouse/actions/runs/17999041936/job/51204006964) and uploading the image to[ GitHub's Container Registry ](https://github.com/waldofouche/lighthouse/pkgs/container/lighthouse)

The newly built image was successfully deploy to our cluster and running without issue. Another benefit is that now on M series Macs, the image does not need to be run with a translation layer. 




