### PR TITLE
Add tests for Entity Configuration admin API endpoints

### DIFF
--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -1128,3 +1128,446 @@ func TestPutMetadata(t *testing.T) {
 		}
 	})
 }
+
+func TestGetMetadataClaim(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	metaJSON := `{"openid_provider":{"issuer":"https://example.com","some_claim":123}}`
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(metaJSON), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != `"https://example.com"` {
+			t.Errorf("expected string JSON, got %s", body)
+		}
+	})
+
+	t.Run("NoMetadataStored", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("EntityTypeNotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(metaJSON), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/oauth_client/issuer", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("ClaimNotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(metaJSON), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/missing", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPutMetadataClaim(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success_ExistingMeta", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"old":123}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if !strings.Contains(s, `"old":123`) || !strings.Contains(s, `"new":456`) {
+						t.Errorf("expected merged json, got %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Success_NoExistingMeta", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					if !strings.Contains(string(value), `"new":456`) {
+						t.Errorf("expected json, got %s", value)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("EmptyBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(""))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400 for empty body, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreGetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db down during get")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreSetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db down during set")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestDeleteMetadataClaim(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"target":123,"other":456}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if strings.Contains(s, `"target"`) {
+						t.Errorf("claim was not deleted: %s", s)
+					}
+					if !strings.Contains(s, `"other"`) {
+						t.Errorf("wrong claim deleted: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NoMetadataStored", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("EntityTypeNotInMeta", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"other_type":{"target":123}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					t.Errorf("set should not be called")
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreGetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreSetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"target":123}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -550,3 +550,131 @@ func TestGetAdditionalClaimByID(t *testing.T) {
 		}
 	})
 }
+
+func TestPutAdditionalClaimByID(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				updateFn: func(ident string, item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return &smodel.EntityConfigurationAdditionalClaim{
+						ID: 5, Claim: item.Claim, Value: item.Value, Crit: item.Crit,
+					}, nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"UpdatedACME","crit":true}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		var got smodel.EntityConfigurationAdditionalClaim
+		if err := json.Unmarshal(respBody, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if got.Claim != "org_name" || got.Crit != true {
+			t.Errorf("unexpected response: %+v", got)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader("bad"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, smodel.NotFoundError("not found")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"X","crit":false}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/999", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("AlreadyExists", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, smodel.AlreadyExistsError("duplicate claim")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"X","crit":false}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("db down")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"X","crit":false}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -368,3 +368,185 @@ func TestPutAdditionalClaims(t *testing.T) {
 		}
 	})
 }
+
+func TestPostAdditionalClaim(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				createFn: func(item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return &smodel.EntityConfigurationAdditionalClaim{
+						ID: 1, Claim: item.Claim, Value: item.Value, Crit: item.Crit,
+					}, nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"ACME","crit":false}`
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("expected status 201, got %d", resp.StatusCode)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		var got smodel.EntityConfigurationAdditionalClaim
+		if err := json.Unmarshal(respBody, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if got.Claim != "org_name" {
+			t.Errorf("expected claim %q, got %q", "org_name", got.Claim)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader("bad"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("AlreadyExists", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				createFn: func(_ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, smodel.AlreadyExistsError("claim already exists")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"ACME","crit":false}`
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				createFn: func(_ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("db down")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `{"claim":"org_name","value":"ACME","crit":false}`
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestGetAdditionalClaimByID(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				getFn: func(ident string) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return &smodel.EntityConfigurationAdditionalClaim{
+						ID: 42, Claim: "org_name", Value: "ACME",
+					}, nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/42", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		var got smodel.EntityConfigurationAdditionalClaim
+		if err := json.Unmarshal(respBody, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if got.ID != 42 || got.Claim != "org_name" {
+			t.Errorf("unexpected response: %+v", got)
+		}
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/abc", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				getFn: func(_ string) (*smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("not found")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/99", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	oidfed "github.com/go-oidfed/lib"
@@ -253,6 +254,111 @@ func TestGetAdditionalClaims(t *testing.T) {
 		)
 
 		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPutAdditionalClaims(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				setFn: func(items []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
+					return []smodel.EntityConfigurationAdditionalClaim{
+						{ID: 1, Claim: items[0].Claim, Value: items[0].Value, Crit: items[0].Crit},
+					}, nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		respBody, _ := io.ReadAll(resp.Body)
+		var got []smodel.EntityConfigurationAdditionalClaim
+		if err := json.Unmarshal(respBody, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if len(got) != 1 || got[0].Claim != "org_name" {
+			t.Errorf("unexpected response: %+v", got)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader("not-json"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("UniqueConstraintError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				setFn: func(_ []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("UNIQUE constraint failed: claims.claim")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				setFn: func(_ []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("db down")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, -1)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -678,3 +678,70 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 		}
 	})
 }
+
+func TestDeleteAdditionalClaimByID(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				deleteFn: func(ident string) error {
+					return nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/42", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/abc", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				deleteFn: func(_ string) error {
+					return errors.New("not found error from db")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/99", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -28,11 +28,12 @@ func (m *mockFederationEntity) EntityID() string { return m.entityID }
 func (m *mockFederationEntity) EntityConfigurationPayload() (*oidfed.EntityStatementPayload, error) {
 	return m.entityConfigurationPayloadFn()
 }
-func (_ *mockFederationEntity) EntityConfigurationJWT() ([]byte, error) { return nil, nil }
-func (_ *mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPayload) ([]byte, error) {
+func (*mockFederationEntity) EntityConfigurationJWT() ([]byte, error) { return nil, nil }
+func (*mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPayload) ([]byte, error) {
 	return nil, nil
 }
-func (_ *mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
+
+func (*mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
 	return nil, nil
 }
 
@@ -48,18 +49,23 @@ type mockAdditionalClaimsStore struct {
 func (m *mockAdditionalClaimsStore) List() ([]smodel.EntityConfigurationAdditionalClaim, error) {
 	return m.listFn()
 }
+
 func (m *mockAdditionalClaimsStore) Set(items []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
 	return m.setFn(items)
 }
+
 func (m *mockAdditionalClaimsStore) Create(item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 	return m.createFn(item)
 }
+
 func (m *mockAdditionalClaimsStore) Get(ident string) (*smodel.EntityConfigurationAdditionalClaim, error) {
 	return m.getFn(ident)
 }
+
 func (m *mockAdditionalClaimsStore) Update(ident string, item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 	return m.updateFn(ident, item)
 }
+
 func (m *mockAdditionalClaimsStore) Delete(ident string) error {
 	return m.deleteFn(ident)
 }
@@ -75,15 +81,19 @@ type mockKeyValueStore struct {
 func (m *mockKeyValueStore) Get(scope, key string) (datatypes.JSON, error) {
 	return m.getFn(scope, key)
 }
+
 func (m *mockKeyValueStore) GetAs(scope, key string, out any) (bool, error) {
 	return m.getAsFn(scope, key, out)
 }
+
 func (m *mockKeyValueStore) Set(scope, key string, value datatypes.JSON) error {
 	return m.setFn(scope, key, value)
 }
+
 func (m *mockKeyValueStore) SetAny(scope, key string, v any) error {
 	return m.setAnyFn(scope, key, v)
 }
+
 func (m *mockKeyValueStore) Delete(scope, key string) error {
 	return m.deleteFn(scope, key)
 }

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -1,9 +1,118 @@
 package adminapi
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"testing"
+
+	oidfed "github.com/go-oidfed/lib"
+	"github.com/gofiber/fiber/v2"
+	"github.com/lestrrat-go/jwx/v3/jws"
+
+	smodel "github.com/go-oidfed/lighthouse/storage/model"
+	"gorm.io/datatypes"
 )
+
+// ---------------------------------------------------------------------------
+// Mock: FederationEntity
+// ---------------------------------------------------------------------------
+
+type mockFederationEntity struct {
+	entityID                     string
+	entityConfigurationPayloadFn func() (*oidfed.EntityStatementPayload, error)
+}
+
+func (m *mockFederationEntity) EntityID() string { return m.entityID }
+func (m *mockFederationEntity) EntityConfigurationPayload() (*oidfed.EntityStatementPayload, error) {
+	return m.entityConfigurationPayloadFn()
+}
+func (m *mockFederationEntity) EntityConfigurationJWT() ([]byte, error) { return nil, nil }
+func (m *mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPayload) ([]byte, error) {
+	return nil, nil
+}
+func (m *mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// Mock: AdditionalClaimsStore
+// ---------------------------------------------------------------------------
+
+type mockAdditionalClaimsStore struct {
+	listFn   func() ([]smodel.EntityConfigurationAdditionalClaim, error)
+	setFn    func([]smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error)
+	createFn func(smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error)
+	getFn    func(string) (*smodel.EntityConfigurationAdditionalClaim, error)
+	updateFn func(string, smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error)
+	deleteFn func(string) error
+}
+
+func (m *mockAdditionalClaimsStore) List() ([]smodel.EntityConfigurationAdditionalClaim, error) {
+	return m.listFn()
+}
+func (m *mockAdditionalClaimsStore) Set(items []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
+	return m.setFn(items)
+}
+func (m *mockAdditionalClaimsStore) Create(item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+	return m.createFn(item)
+}
+func (m *mockAdditionalClaimsStore) Get(ident string) (*smodel.EntityConfigurationAdditionalClaim, error) {
+	return m.getFn(ident)
+}
+func (m *mockAdditionalClaimsStore) Update(ident string, item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
+	return m.updateFn(ident, item)
+}
+func (m *mockAdditionalClaimsStore) Delete(ident string) error {
+	return m.deleteFn(ident)
+}
+
+// ---------------------------------------------------------------------------
+// Mock: KeyValueStore
+// ---------------------------------------------------------------------------
+
+type mockKeyValueStore struct {
+	getFn    func(scope, key string) (datatypes.JSON, error)
+	getAsFn  func(scope, key string, out any) (bool, error)
+	setFn    func(scope, key string, value datatypes.JSON) error
+	setAnyFn func(scope, key string, v any) error
+	deleteFn func(scope, key string) error
+}
+
+func (m *mockKeyValueStore) Get(scope, key string) (datatypes.JSON, error) {
+	return m.getFn(scope, key)
+}
+func (m *mockKeyValueStore) GetAs(scope, key string, out any) (bool, error) {
+	return m.getAsFn(scope, key, out)
+}
+func (m *mockKeyValueStore) Set(scope, key string, value datatypes.JSON) error {
+	return m.setFn(scope, key, value)
+}
+func (m *mockKeyValueStore) SetAny(scope, key string, v any) error {
+	return m.setAnyFn(scope, key, v)
+}
+func (m *mockKeyValueStore) Delete(scope, key string) error {
+	return m.deleteFn(scope, key)
+}
+
+// ---------------------------------------------------------------------------
+// Test helper: create a Fiber app with the entity configuration routes
+// ---------------------------------------------------------------------------
+
+func setupEntityConfigTestApp(
+	fedEntity oidfed.FederationEntity,
+	claims smodel.AdditionalClaimsStore,
+	kv smodel.KeyValueStore,
+) *fiber.App {
+	app := fiber.New()
+	registerEntityConfiguration(app, claims, kv, fedEntity)
+	return app
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 func TestIsUniqueConstraintError(t *testing.T) {
 	tests := []struct {
@@ -28,4 +137,63 @@ func TestIsUniqueConstraintError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetEntityConfiguration(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		payload := &oidfed.EntityStatementPayload{
+			Issuer:  "https://example.com",
+			Subject: "https://example.com",
+		}
+		app := setupEntityConfigTestApp(
+			&mockFederationEntity{
+				entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+					return payload, nil
+				},
+			},
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var got oidfed.EntityStatementPayload
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if got.Issuer != "https://example.com" {
+			t.Errorf("expected issuer %q, got %q", "https://example.com", got.Issuer)
+		}
+		if got.Subject != "https://example.com" {
+			t.Errorf("expected subject %q, got %q", "https://example.com", got.Subject)
+		}
+	})
+
+	t.Run("FedEntityError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			&mockFederationEntity{
+				entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+					return nil, errors.New("boom")
+				},
+			},
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
 }

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -1,0 +1,31 @@
+package adminapi
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsUniqueConstraintError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"NilError", nil, false},
+		{"SQLiteUNIQUEConstraintFailed", errors.New("UNIQUE constraint failed: table.column"), true},
+		{"SQLiteConstraintFailed", errors.New("constraint failed"), true},
+		{"MySQLDuplicateEntry", errors.New("Duplicate entry 'val' for key 'idx'"), true},
+		{"MySQLError1062", errors.New("Error 1062: ..."), true},
+		{"PostgresDuplicateKeyValue", errors.New("duplicate key value violates unique constraint"), true},
+		{"PostgresViolatesUniqueConstraint", errors.New("violates unique constraint \"idx\""), true},
+		{"UnrelatedError", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUniqueConstraintError(tt.err)
+			if got != tt.want {
+				t.Errorf("isUniqueConstraintError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -1571,3 +1571,540 @@ func TestDeleteMetadataClaim(t *testing.T) {
 		}
 	})
 }
+
+func TestGetMetadataEntityType(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"issuer":"https://example.com"}}`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		var got map[string]json.RawMessage
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to decode: %v", err)
+		}
+		if string(got["issuer"]) != `"https://example.com"` {
+			t.Errorf("expected url, got %s", got["issuer"])
+		}
+	})
+
+	t.Run("NoMetadataStored", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "{}" {
+			t.Errorf("expected {}, got %s", body)
+		}
+	})
+
+	t.Run("EntityTypeNotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"oauth_client":{"x":1}}`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "{}" {
+			t.Errorf("expected {}, got %s", body)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPutMetadataEntityType(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"old":1},"other":{}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if strings.Contains(s, `"old":1`) {
+						t.Errorf("should have replaced openid_provider entirely: %s", s)
+					}
+					if !strings.Contains(s, `"new":2`) {
+						t.Errorf("should contain new value: %s", s)
+					}
+					if !strings.Contains(s, `"other"`) {
+						t.Errorf("should retain other types: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreGetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreSetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPostMetadataEntityType(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success_MergesInto", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"old":1}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if !strings.Contains(s, `"old":1`) || !strings.Contains(s, `"new":2`) {
+						t.Errorf("should merge existing and new: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("Success_CreatesNew", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if !strings.Contains(s, `"openid_provider":{"new":2}`) {
+						t.Errorf("should create new: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreGetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreSetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestDeleteMetadataEntityType(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"target":123},"other":{}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if strings.Contains(s, `"openid_provider"`) {
+						t.Errorf("entity type was not deleted: %s", s)
+					}
+					if !strings.Contains(s, `"other"`) {
+						t.Errorf("wrong entity type deleted: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NoMetadataStored", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreGetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreSetError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"target":123}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -197,3 +197,68 @@ func TestGetEntityConfiguration(t *testing.T) {
 		}
 	})
 }
+
+func TestGetAdditionalClaims(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		claims := []smodel.EntityConfigurationAdditionalClaim{
+			{ID: 1, Claim: "org_name", Value: "ACME", Crit: false},
+			{ID: 2, Claim: "policy_uri", Value: "https://example.com/policy", Crit: true},
+		}
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				listFn: func() ([]smodel.EntityConfigurationAdditionalClaim, error) {
+					return claims, nil
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		var got []smodel.EntityConfigurationAdditionalClaim
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 claims, got %d", len(got))
+		}
+		if got[0].Claim != "org_name" {
+			t.Errorf("expected first claim %q, got %q", "org_name", got[0].Claim)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{
+				listFn: func() ([]smodel.EntityConfigurationAdditionalClaim, error) {
+					return nil, errors.New("db down")
+				},
+			},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -28,11 +28,11 @@ func (m *mockFederationEntity) EntityID() string { return m.entityID }
 func (m *mockFederationEntity) EntityConfigurationPayload() (*oidfed.EntityStatementPayload, error) {
 	return m.entityConfigurationPayloadFn()
 }
-func (m *mockFederationEntity) EntityConfigurationJWT() ([]byte, error) { return nil, nil }
-func (m *mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPayload) ([]byte, error) {
+func (_ *mockFederationEntity) EntityConfigurationJWT() ([]byte, error) { return nil, nil }
+func (_ *mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPayload) ([]byte, error) {
 	return nil, nil
 }
-func (m *mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
+func (_ *mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
 	return nil, nil
 }
 

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -16,9 +17,7 @@ import (
 	"gorm.io/datatypes"
 )
 
-// ---------------------------------------------------------------------------
-// Mock: FederationEntity
-// ---------------------------------------------------------------------------
+// --- MOCKS ---
 
 type mockFederationEntity struct {
 	entityID                     string
@@ -36,10 +35,6 @@ func (m *mockFederationEntity) SignEntityStatement(_ oidfed.EntityStatementPaylo
 func (m *mockFederationEntity) SignEntityStatementWithHeaders(_ oidfed.EntityStatementPayload, _ jws.Headers) ([]byte, error) {
 	return nil, nil
 }
-
-// ---------------------------------------------------------------------------
-// Mock: AdditionalClaimsStore
-// ---------------------------------------------------------------------------
 
 type mockAdditionalClaimsStore struct {
 	listFn   func() ([]smodel.EntityConfigurationAdditionalClaim, error)
@@ -69,10 +64,6 @@ func (m *mockAdditionalClaimsStore) Delete(ident string) error {
 	return m.deleteFn(ident)
 }
 
-// ---------------------------------------------------------------------------
-// Mock: KeyValueStore
-// ---------------------------------------------------------------------------
-
 type mockKeyValueStore struct {
 	getFn    func(scope, key string) (datatypes.JSON, error)
 	getAsFn  func(scope, key string, out any) (bool, error)
@@ -97,9 +88,7 @@ func (m *mockKeyValueStore) Delete(scope, key string) error {
 	return m.deleteFn(scope, key)
 }
 
-// ---------------------------------------------------------------------------
-// Test helper: create a Fiber app with the entity configuration routes
-// ---------------------------------------------------------------------------
+// --- TEST HELPERS ---
 
 func setupEntityConfigTestApp(
 	fedEntity oidfed.FederationEntity,
@@ -111,9 +100,31 @@ func setupEntityConfigTestApp(
 	return app
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+// doRequest executes an HTTP request against a Fiber app and returns the
+// response plus the fully-read body.
+func doRequest(t *testing.T, app *fiber.App, req *http.Request) (*http.Response, []byte) {
+	t.Helper()
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("Request %s %s failed: %v", req.Method, req.URL.Path, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	return resp, body
+}
+
+// newStubFedEntity creates a mock FederationEntity that returns an empty payload.
+func newStubFedEntity() *mockFederationEntity {
+	return &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+}
+
+// --- TESTS ---
 
 func TestIsUniqueConstraintError(t *testing.T) {
 	tests := []struct {
@@ -156,17 +167,13 @@ func TestGetEntityConfiguration(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
 		var got oidfed.EntityStatementPayload
-		if err := json.Unmarshal(body, &got); err != nil {
+		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
 		if got.Issuer != "https://example.com" {
@@ -188,31 +195,22 @@ func TestGetEntityConfiguration(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestGetAdditionalClaims(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		claims := []smodel.EntityConfigurationAdditionalClaim{
 			{ID: 1, Claim: "org_name", Value: "ACME", Crit: false},
 			{ID: 2, Claim: "policy_uri", Value: "https://example.com/policy", Crit: true},
 		}
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				listFn: func() ([]smodel.EntityConfigurationAdditionalClaim, error) {
 					return claims, nil
@@ -221,17 +219,13 @@ func TestGetAdditionalClaims(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/additional-claims", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
 		var got []smodel.EntityConfigurationAdditionalClaim
-		if err := json.Unmarshal(body, &got); err != nil {
+		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
 		if len(got) != 2 {
@@ -244,7 +238,7 @@ func TestGetAdditionalClaims(t *testing.T) {
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				listFn: func() ([]smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("db down")
@@ -253,27 +247,18 @@ func TestGetAdditionalClaims(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/additional-claims", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPutAdditionalClaims(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				setFn: func(items []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
 					return []smodel.EntityConfigurationAdditionalClaim{
@@ -285,16 +270,12 @@ func TestPutAdditionalClaims(t *testing.T) {
 		)
 
 		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		respBody, _ := io.ReadAll(resp.Body)
 		var got []smodel.EntityConfigurationAdditionalClaim
 		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
@@ -306,25 +287,22 @@ func TestPutAdditionalClaims(t *testing.T) {
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader("not-json"))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims", strings.NewReader("not-json"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("UniqueConstraintError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				setFn: func(_ []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("UNIQUE constraint failed: claims.claim")
@@ -334,20 +312,17 @@ func TestPutAdditionalClaims(t *testing.T) {
 		)
 
 		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusConflict {
-			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 409 {
+			t.Fatalf("Expected status 409, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				setFn: func(_ []smodel.AddAdditionalClaim) ([]smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("db down")
@@ -357,28 +332,19 @@ func TestPutAdditionalClaims(t *testing.T) {
 		)
 
 		body := `[{"claim":"org_name","value":"ACME","crit":false}]`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPostAdditionalClaim(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				createFn: func(item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return &smodel.EntityConfigurationAdditionalClaim{
@@ -390,16 +356,12 @@ func TestPostAdditionalClaim(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"ACME","crit":false}`
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("POST", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 201 {
+			t.Fatalf("Expected status 201, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusCreated {
-			t.Fatalf("expected status 201, got %d", resp.StatusCode)
-		}
-		respBody, _ := io.ReadAll(resp.Body)
 		var got smodel.EntityConfigurationAdditionalClaim
 		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
@@ -411,25 +373,22 @@ func TestPostAdditionalClaim(t *testing.T) {
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader("bad"))
+		req := httptest.NewRequest("POST", "/entity-configuration/additional-claims", strings.NewReader("bad"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("AlreadyExists", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				createFn: func(_ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, smodel.AlreadyExistsError("claim already exists")
@@ -439,20 +398,17 @@ func TestPostAdditionalClaim(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"ACME","crit":false}`
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("POST", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusConflict {
-			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 409 {
+			t.Fatalf("Expected status 409, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				createFn: func(_ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("db down")
@@ -462,28 +418,19 @@ func TestPostAdditionalClaim(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"ACME","crit":false}`
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/additional-claims", strings.NewReader(body))
+		req := httptest.NewRequest("POST", "/entity-configuration/additional-claims", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestGetAdditionalClaimByID(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				getFn: func(ident string) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return &smodel.EntityConfigurationAdditionalClaim{
@@ -494,15 +441,11 @@ func TestGetAdditionalClaimByID(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/42", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/additional-claims/42", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		respBody, _ := io.ReadAll(resp.Body)
 		var got smodel.EntityConfigurationAdditionalClaim
 		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
@@ -514,24 +457,21 @@ func TestGetAdditionalClaimByID(t *testing.T) {
 
 	t.Run("InvalidID", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/abc", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/additional-claims/abc", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				getFn: func(_ string) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("not found")
@@ -540,27 +480,18 @@ func TestGetAdditionalClaimByID(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/additional-claims/99", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/additional-claims/99", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPutAdditionalClaimByID(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				updateFn: func(ident string, item smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return &smodel.EntityConfigurationAdditionalClaim{
@@ -572,16 +503,12 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"UpdatedACME","crit":true}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims/5", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		respBody, _ := io.ReadAll(resp.Body)
 		var got smodel.EntityConfigurationAdditionalClaim
 		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
@@ -593,25 +520,22 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader("bad"))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims/5", strings.NewReader("bad"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, smodel.NotFoundError("not found")
@@ -621,20 +545,17 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"X","crit":false}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/999", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims/999", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("AlreadyExists", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, smodel.AlreadyExistsError("duplicate claim")
@@ -644,20 +565,17 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"X","crit":false}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims/5", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusConflict {
-			t.Fatalf("expected status 409, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 409 {
+			t.Fatalf("Expected status 409, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				updateFn: func(_ string, _ smodel.AddAdditionalClaim) (*smodel.EntityConfigurationAdditionalClaim, error) {
 					return nil, errors.New("db down")
@@ -667,28 +585,19 @@ func TestPutAdditionalClaimByID(t *testing.T) {
 		)
 
 		body := `{"claim":"org_name","value":"X","crit":false}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/additional-claims/5", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/additional-claims/5", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestDeleteAdditionalClaimByID(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				deleteFn: func(ident string) error {
 					return nil
@@ -697,36 +606,30 @@ func TestDeleteAdditionalClaimByID(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/42", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/additional-claims/42", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("InvalidID", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/abc", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/additional-claims/abc", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{
 				deleteFn: func(_ string) error {
 					return errors.New("not found error from db")
@@ -735,27 +638,18 @@ func TestDeleteAdditionalClaimByID(t *testing.T) {
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/additional-claims/99", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/additional-claims/99", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestGetLifetime(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getAsFn: func(scope, key string, out any) (bool, error) {
@@ -769,23 +663,19 @@ func TestGetLifetime(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/lifetime", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "3600" {
-			t.Errorf("expected 3600, got %q", string(body))
+		if string(respBody) != "3600" {
+			t.Errorf("expected 3600, got %q", string(respBody))
 		}
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getAsFn: func(scope, key string, out any) (bool, error) {
@@ -794,23 +684,19 @@ func TestGetLifetime(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/lifetime", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "86400" {
-			t.Errorf("expected 86400, got %q", string(body))
+		if string(respBody) != "86400" {
+			t.Errorf("expected 86400, got %q", string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getAsFn: func(scope, key string, out any) (bool, error) {
@@ -819,27 +705,41 @@ func TestGetLifetime(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/lifetime", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+	})
+
+	t.Run("ZeroValueReturnsDefault", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			newStubFedEntity(),
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getAsFn: func(scope, key string, out any) (bool, error) {
+					ptr := out.(*int)
+					*ptr = 0
+					return true, nil
+				},
+			},
+		)
+
+		req := httptest.NewRequest("GET", "/entity-configuration/lifetime", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
+		}
+		if string(respBody) != "86400" {
+			t.Errorf("expected default 86400 for zero stored value, got %q", string(respBody))
 		}
 	})
 }
 
 func TestPutLifetime(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				setAnyFn: func(scope, key string, v any) error {
@@ -854,78 +754,65 @@ func TestPutLifetime(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("7200"))
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader("7200"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "7200" {
-			t.Errorf("expected 7200 in response, got %q", string(body))
+		if string(respBody) != "7200" {
+			t.Errorf("expected 7200 in response, got %q", string(respBody))
 		}
 	})
 
 	t.Run("EmptyBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader(""))
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader(""))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader(`"not-int"`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader(`"not-int"`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400 for string body, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NegativeValue", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("-3600"))
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader("-3600"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400 for negative, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				setAnyFn: func(scope, key string, v any) error {
@@ -934,28 +821,44 @@ func TestPutLifetime(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("3600"))
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader("3600"))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+	})
+
+	t.Run("ZeroValueSuccess", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			newStubFedEntity(),
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				setAnyFn: func(scope, key string, v any) error {
+					if v.(int) != 0 {
+						t.Errorf("expected 0 to be saved, got %v", v)
+					}
+					return nil
+				},
+			},
+		)
+
+		req := httptest.NewRequest("PUT", "/entity-configuration/lifetime", strings.NewReader("0"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
+		}
+		if string(respBody) != "0" {
+			t.Errorf("expected 0 in response, got %q", string(respBody))
 		}
 	})
 }
 
 func TestGetMetadata(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -967,16 +870,13 @@ func TestGetMetadata(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 		var got oidfed.Metadata
-		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to parse metadata: %v", err)
 		}
 		if got.OpenIDProvider == nil || got.OpenIDProvider.Issuer != "https://example.com" {
@@ -986,7 +886,7 @@ func TestGetMetadata(t *testing.T) {
 
 	t.Run("NoMetadataStored", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -995,23 +895,19 @@ func TestGetMetadata(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "{}" {
-			t.Errorf("expected {}, got %q", string(body))
+		if string(respBody) != "{}" {
+			t.Errorf("expected {}, got %q", string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1020,19 +916,16 @@ func TestGetMetadata(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1041,27 +934,18 @@ func TestGetMetadata(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPutMetadata(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				setFn: func(scope, key string, value datatypes.JSON) error {
@@ -1076,38 +960,32 @@ func TestPutMetadata(t *testing.T) {
 		)
 
 		body := `{"openid_provider":{"issuer":"https://example.com"}}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(`"not-an-object"`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata", strings.NewReader(`"not-an-object"`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				setFn: func(scope, key string, value datatypes.JSON) error {
@@ -1117,30 +995,21 @@ func TestPutMetadata(t *testing.T) {
 		)
 
 		body := `{"openid_provider":{"issuer":"https://example.com"}}`
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(body))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestGetMetadataClaim(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	metaJSON := `{"openid_provider":{"issuer":"https://example.com","some_claim":123}}`
 
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1149,23 +1018,19 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider/issuer", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != `"https://example.com"` {
-			t.Errorf("expected string JSON, got %s", body)
+		if string(respBody) != `"https://example.com"` {
+			t.Errorf("expected string JSON, got %s", respBody)
 		}
 	})
 
 	t.Run("NoMetadataStored", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1174,19 +1039,16 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider/issuer", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("EntityTypeNotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1195,19 +1057,16 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/oauth_client/issuer", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/oauth_client/issuer", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("ClaimNotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1216,19 +1075,16 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/missing", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected status 404, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider/missing", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 404 {
+			t.Fatalf("Expected status 404, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1237,19 +1093,16 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider/issuer", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1258,27 +1111,18 @@ func TestGetMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider/issuer", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider/issuer", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPutMetadataClaim(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success_ExistingMeta", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1294,20 +1138,17 @@ func TestPutMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("Success_NoExistingMeta", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1322,38 +1163,32 @@ func TestPutMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("EmptyBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(""))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(""))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400 for empty body, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreGetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1362,20 +1197,17 @@ func TestPutMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreSetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1387,20 +1219,17 @@ func TestPutMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1409,28 +1238,19 @@ func TestPutMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider/new", strings.NewReader(`456`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestDeleteMetadataClaim(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1449,19 +1269,41 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	})
+
+	t.Run("LastClaimRemovesEntityType", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			newStubFedEntity(),
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{"openid_provider":{"only_claim":1}}`), nil
+				},
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					s := string(value)
+					if strings.Contains(s, `"openid_provider"`) {
+						t.Errorf("entity type should be removed when its last claim is deleted: %s", s)
+					}
+					return nil
+				},
+			},
+		)
+
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/only_claim", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NoMetadataStored", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1470,19 +1312,16 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("EntityTypeNotInMeta", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1495,19 +1334,16 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1516,19 +1352,16 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreGetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1537,19 +1370,16 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreSetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1561,27 +1391,18 @@ func TestDeleteMetadataClaim(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider/target", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider/target", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestGetMetadataEntityType(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1590,16 +1411,13 @@ func TestGetMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 		var got map[string]json.RawMessage
-		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		if err := json.Unmarshal(respBody, &got); err != nil {
 			t.Fatalf("failed to decode: %v", err)
 		}
 		if string(got["issuer"]) != `"https://example.com"` {
@@ -1609,7 +1427,7 @@ func TestGetMetadataEntityType(t *testing.T) {
 
 	t.Run("NoMetadataStored", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1618,23 +1436,19 @@ func TestGetMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "{}" {
-			t.Errorf("expected {}, got %s", body)
+		if string(respBody) != "{}" {
+			t.Errorf("expected {}, got %s", respBody)
 		}
 	})
 
 	t.Run("EntityTypeNotFound", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1643,23 +1457,19 @@ func TestGetMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
-		}
-		body, _ := io.ReadAll(resp.Body)
-		if string(body) != "{}" {
-			t.Errorf("expected {}, got %s", body)
+		if string(respBody) != "{}" {
+			t.Errorf("expected {}, got %s", respBody)
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1668,19 +1478,16 @@ func TestGetMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1689,27 +1496,18 @@ func TestGetMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("GET", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPutMetadataEntityType(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1731,38 +1529,32 @@ func TestPutMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreGetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1771,20 +1563,17 @@ func TestPutMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreSetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1796,20 +1585,17 @@ func TestPutMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1818,28 +1604,19 @@ func TestPutMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("PUT", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestPostMetadataEntityType(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success_MergesInto", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1855,20 +1632,17 @@ func TestPostMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("Success_CreatesNew", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1884,38 +1658,32 @@ func TestPostMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 200 {
+			t.Fatalf("Expected status 200, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("InvalidBody", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`not-json`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("Expected status 400, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreGetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1924,20 +1692,17 @@ func TestPostMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreSetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1949,20 +1714,17 @@ func TestPostMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -1971,28 +1733,19 @@ func TestPostMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodPost, "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
+		req := httptest.NewRequest("POST", "/entity-configuration/metadata/openid_provider", strings.NewReader(`{"new":2}`))
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }
 
 func TestDeleteMetadataEntityType(t *testing.T) {
-	stubFedEntity := &mockFederationEntity{
-		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
-			return &oidfed.EntityStatementPayload{}, nil
-		},
-	}
-
 	t.Run("Success", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -2011,19 +1764,16 @@ func TestDeleteMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("NoMetadataStored", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -2032,19 +1782,16 @@ func TestDeleteMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusNoContent {
-			t.Fatalf("expected status 204, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 204 {
+			t.Fatalf("Expected status 204, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("CorruptStoredMetadata", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -2053,19 +1800,16 @@ func TestDeleteMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreGetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -2074,19 +1818,16 @@ func TestDeleteMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 
 	t.Run("StoreSetError", func(t *testing.T) {
 		app := setupEntityConfigTestApp(
-			stubFedEntity,
+			newStubFedEntity(),
 			&mockAdditionalClaimsStore{},
 			&mockKeyValueStore{
 				getFn: func(scope, key string) (datatypes.JSON, error) {
@@ -2098,13 +1839,10 @@ func TestDeleteMetadataEntityType(t *testing.T) {
 			},
 		)
 
-		req, _ := http.NewRequest(http.MethodDelete, "/entity-configuration/metadata/openid_provider", nil)
-		resp, err := app.Test(req, -1)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp.StatusCode != http.StatusInternalServerError {
-			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		req := httptest.NewRequest("DELETE", "/entity-configuration/metadata/openid_provider", http.NoBody)
+		resp, respBody := doRequest(t, app, req)
+		if resp.StatusCode != 500 {
+			t.Fatalf("Expected status 500, got %d. Body: %s", resp.StatusCode, string(respBody))
 		}
 	})
 }

--- a/api/adminapi/entity_configuration_test.go
+++ b/api/adminapi/entity_configuration_test.go
@@ -745,3 +745,386 @@ func TestDeleteAdditionalClaimByID(t *testing.T) {
 		}
 	})
 }
+
+func TestGetLifetime(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getAsFn: func(scope, key string, out any) (bool, error) {
+					if scope == smodel.KeyValueScopeEntityConfiguration && key == smodel.KeyValueKeyLifetime {
+						ptr := out.(*int)
+						*ptr = 3600
+						return true, nil
+					}
+					return false, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "3600" {
+			t.Errorf("expected 3600, got %q", string(body))
+		}
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getAsFn: func(scope, key string, out any) (bool, error) {
+					return false, nil // Not found
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "86400" {
+			t.Errorf("expected 86400, got %q", string(body))
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getAsFn: func(scope, key string, out any) (bool, error) {
+					return false, errors.New("kv db down")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/lifetime", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPutLifetime(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				setAnyFn: func(scope, key string, v any) error {
+					if scope == smodel.KeyValueScopeEntityConfiguration && key == smodel.KeyValueKeyLifetime {
+						val := v.(int)
+						if val != 7200 {
+							t.Errorf("expected 7200 to be saved, got %d", val)
+						}
+					}
+					return nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("7200"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "7200" {
+			t.Errorf("expected 7200 in response, got %q", string(body))
+		}
+	})
+
+	t.Run("EmptyBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader(""))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader(`"not-int"`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400 for string body, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("NegativeValue", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("-3600"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400 for negative, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				setAnyFn: func(scope, key string, v any) error {
+					return errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/lifetime", strings.NewReader("3600"))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestGetMetadata(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					if scope == smodel.KeyValueScopeEntityConfiguration && key == smodel.KeyValueKeyMetadata {
+						return datatypes.JSON(`{"openid_provider":{"issuer":"https://example.com"}}`), nil
+					}
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		var got oidfed.Metadata
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("failed to parse metadata: %v", err)
+		}
+		if got.OpenIDProvider == nil || got.OpenIDProvider.Issuer != "https://example.com" {
+			t.Errorf("expected op.issuer=https://example.com, got %+v", got.OpenIDProvider)
+		}
+	})
+
+	t.Run("NoMetadataStored", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if string(body) != "{}" {
+			t.Errorf("expected {}, got %q", string(body))
+		}
+	})
+
+	t.Run("CorruptStoredMetadata", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return datatypes.JSON(`{bad-json`), nil
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				getFn: func(scope, key string) (datatypes.JSON, error) {
+					return nil, errors.New("db error")
+				},
+			},
+		)
+
+		req, _ := http.NewRequest(http.MethodGet, "/entity-configuration/metadata", nil)
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestPutMetadata(t *testing.T) {
+	stubFedEntity := &mockFederationEntity{
+		entityConfigurationPayloadFn: func() (*oidfed.EntityStatementPayload, error) {
+			return &oidfed.EntityStatementPayload{}, nil
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					if scope == smodel.KeyValueScopeEntityConfiguration && key == smodel.KeyValueKeyMetadata {
+						if !strings.Contains(string(value), "https://example.com") {
+							t.Errorf("expected string to contain issuer, got %s", value)
+						}
+					}
+					return nil
+				},
+			},
+		)
+
+		body := `{"openid_provider":{"issuer":"https://example.com"}}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{},
+		)
+
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(`"not-an-object"`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("StoreError", func(t *testing.T) {
+		app := setupEntityConfigTestApp(
+			stubFedEntity,
+			&mockAdditionalClaimsStore{},
+			&mockKeyValueStore{
+				setFn: func(scope, key string, value datatypes.JSON) error {
+					return errors.New("db down")
+				},
+			},
+		)
+
+		body := `{"openid_provider":{"issuer":"https://example.com"}}`
+		req, _ := http.NewRequest(http.MethodPut, "/entity-configuration/metadata", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, -1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
## Overview
The tests ensures that all Entity Configuration CRUD operations (metadata, lifetime, and additional claims) are functioning correctly and handle edge cases gracefully.

## Endpoints Verified
A total of **84 test cases** were successfully implemented covering the following routes:

**Entity Configuration**
- `GET /entity-configuration/`

**Additional Claims**
- `GET /entity-configuration/additional-claims` (List)
- `POST /entity-configuration/additional-claims` (Create)
- `PUT /entity-configuration/additional-claims` (Bulk Update)
- `GET /entity-configuration/additional-claims/:id` (Get One)
- `PUT /entity-configuration/additional-claims/:id` (Update One)
- `DELETE /entity-configuration/additional-claims/:id` (Delete One)

**Lifetime**
- `GET /entity-configuration/lifetime` (Includes default 24h fallback test)
- `PUT /entity-configuration/lifetime` 

**Metadata Management**
- `GET & PUT /entity-configuration/metadata` (Full Metadata)
- `GET, POST, PUT, DELETE /entity-configuration/metadata/:entityType` (Entity Type Level)
- `GET, PUT, DELETE /entity-configuration/metadata/:entityType/:claim` (Specific Claim Level)

