### PR TITLE
fix(storage): change sql alias 'set' to 'setypes' to fix syntax error

### DIFF
--- a/storage/subordinates_storage.go
+++ b/storage/subordinates_storage.go
@@ -303,13 +303,13 @@ func (s *SubordinateStorage) buildEntityTypeJoin(status *model.Status, entityTyp
 	}
 	subTable := s.db.NamingStrategy.TableName("subordinates")
 	joinTable := s.db.NamingStrategy.TableName("subordinate_entity_types")
-	db := s.db.Table(subTable + " as s").Joins("JOIN " + joinTable + " as set ON set.subordinate_id = s.id")
+	db := s.db.Table(subTable + " as s").Joins("JOIN " + joinTable + " as setypes ON setypes.subordinate_id = s.id")
 	if status != nil {
 		db = db.Where("s.status = ?", *status)
 	}
-	db = db.Where("set.entity_type IN ?", entityTypes)
+	db = db.Where("setypes.entity_type IN ?", entityTypes)
 	if requireAll {
-		db = db.Select("s.id").Group("s.id").Having("COUNT(DISTINCT set.entity_type) = ?", len(entityTypes))
+		db = db.Select("s.id").Group("s.id").Having("COUNT(DISTINCT setypes.entity_type) = ?", len(entityTypes))
 	} else {
 		db = db.Select("DISTINCT s.id")
 	}


### PR DESCRIPTION
**Fix: Resolve SQLite syntax error on subordinates endpoint**

* **Issue:** `GET /subordinates?entity_type=<type>` returned 500 due to `near "set": syntax error`.
* **Cause:** Used reserved keyword `set` as a table alias in `storage/subordinates_storage.go`.
* **Fix:** Renamed alias `set` → `setypes`.