### PR TITLE
Add gorm dialect for db_pem_storer

### DIFF
--- a/storage/db_pem_storer.go
+++ b/storage/db_pem_storer.go
@@ -47,14 +47,14 @@ func (d *DBPEMStorer) ReadPEM(kid string) ([]byte, error) {
 		}
 		return nil, errors.WithStack(err)
 	}
-	return row.PEMData, nil
+	return []byte(row.PEMData), nil
 }
 
 // WritePEM stores or updates a PEM-encoded private key by KID.
 func (d *DBPEMStorer) WritePEM(kid string, data []byte) error {
 	entry := model.PrivateKeyEntry{
 		KID:     kid,
-		PEMData: data,
+		PEMData: model.PEMData(data),
 	}
 	return errors.WithStack(
 		d.db.Session(&gorm.Session{NewDB: true}).Table(d.tbl).Clauses(

--- a/storage/model/keys.go
+++ b/storage/model/keys.go
@@ -44,7 +44,7 @@ func NewJWKS(jwks jwx.JWKS) JWKS {
 // PrivateKeyEntry represents a private key stored in the database.
 type PrivateKeyEntry struct {
 	KID       string `gorm:"primaryKey;size:255;column:kid"`
-	PEMData   []byte `gorm:"column:pem_data;type:bytea;not null"`
+	PEMData   PEMData `gorm:"column:pem_data;not null"`
 	CreatedAt int64  `gorm:"autoCreateTime"`
 	UpdatedAt int64  `gorm:"autoUpdateTime"`
 }

--- a/storage/model/pem_data.go
+++ b/storage/model/pem_data.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+// PEMData stores PEM-encoded private key bytes with dialect-specific migration support.
+type PEMData []byte
+
+// GormDataType declares a generic logical type for GORM.
+func (PEMData) GormDataType() string {
+	return "bytes"
+}
+
+// GormDBDataType maps PEMData to a database-specific column type.
+func (PEMData) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
+	return pemDataColumnType(db.Dialector.Name())
+}
+
+func pemDataColumnType(dialect string) string {
+	switch strings.ToLower(dialect) {
+	case "mysql":
+		return "longblob"
+	case "postgres":
+		return "bytea"
+	case "sqlite":
+		return "blob"
+	default:
+		return "blob"
+	}
+}
+
+// Value implements driver.Valuer so PEMData can be stored by database drivers.
+func (p PEMData) Value() (driver.Value, error) {
+	if p == nil {
+		return nil, nil
+	}
+	return []byte(p), nil
+}
+
+// Scan implements sql.Scanner so PEMData can be read from database drivers.
+func (p *PEMData) Scan(value any) error {
+	switch v := value.(type) {
+	case nil:
+		*p = nil
+		return nil
+	case []byte:
+		*p = append((*p)[:0], v...)
+		return nil
+	case string:
+		*p = append((*p)[:0], v...)
+		return nil
+	default:
+		return fmt.Errorf("unsupported PEMData scan type %T", value)
+	}
+}
+

--- a/storage/model/pem_data.go
+++ b/storage/model/pem_data.go
@@ -3,8 +3,6 @@ package model
 import (
 	"database/sql/driver"
 	"fmt"
-	"strings"
-
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 )
@@ -19,11 +17,7 @@ func (PEMData) GormDataType() string {
 
 // GormDBDataType maps PEMData to a database-specific column type.
 func (PEMData) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
-	return pemDataColumnType(db.Dialector.Name())
-}
-
-func pemDataColumnType(dialect string) string {
-	switch strings.ToLower(dialect) {
+	switch db.Dialector.Name() {
 	case "mysql":
 		return "longblob"
 	case "postgres":
@@ -59,4 +53,3 @@ func (p *PEMData) Scan(value any) error {
 		return fmt.Errorf("unsupported PEMData scan type %T", value)
 	}
 }
-

--- a/storage/model/pem_data_test.go
+++ b/storage/model/pem_data_test.go
@@ -11,13 +11,13 @@ import (
 type fakeDialector string
 
 func (d fakeDialector) Name() string                                   { return string(d) }
-func (d fakeDialector) Initialize(*gorm.DB) error                      { return nil }
-func (d fakeDialector) Migrator(*gorm.DB) gorm.Migrator                { return nil }
-func (d fakeDialector) DataTypeOf(*schema.Field) string                { return "" }
-func (d fakeDialector) DefaultValueOf(*schema.Field) clause.Expression { return nil }
-func (d fakeDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  {}
-func (d fakeDialector) QuoteTo(clause.Writer, string)                  {}
-func (d fakeDialector) Explain(string, ...any) string                  { return "" }
+func (d fakeDialector) Initialize(*gorm.DB) error                      { _ = d; return nil }
+func (d fakeDialector) Migrator(*gorm.DB) gorm.Migrator                { _ = d; return nil }
+func (d fakeDialector) DataTypeOf(*schema.Field) string                { _ = d; return "" }
+func (d fakeDialector) DefaultValueOf(*schema.Field) clause.Expression { _ = d; return nil }
+func (d fakeDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  { _ = d }
+func (d fakeDialector) QuoteTo(clause.Writer, string)                  { _ = d }
+func (d fakeDialector) Explain(string, ...any) string                  { _ = d; return "" }
 
 func TestPEMDataColumnType(t *testing.T) {
 	tests := []struct {
@@ -31,7 +31,7 @@ func TestPEMDataColumnType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		db, err := gorm.Open(fakeDialector(tt.dialect), &gorm.Config{})
+		db, err := gorm.Open(fakeDialector(tt.dialect), &gorm.Config{SkipDefaultTransaction: true})
 		if err != nil {
 			t.Fatalf("gorm.Open(%q) returned error: %v", tt.dialect, err)
 		}

--- a/storage/model/pem_data_test.go
+++ b/storage/model/pem_data_test.go
@@ -2,8 +2,22 @@ package model
 
 import (
 	"bytes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 	"testing"
 )
+
+type fakeDialector string
+
+func (d fakeDialector) Name() string                                   { return string(d) }
+func (d fakeDialector) Initialize(*gorm.DB) error                      { return nil }
+func (d fakeDialector) Migrator(*gorm.DB) gorm.Migrator                { return nil }
+func (d fakeDialector) DataTypeOf(*schema.Field) string                { return "" }
+func (d fakeDialector) DefaultValueOf(*schema.Field) clause.Expression { return nil }
+func (d fakeDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  {}
+func (d fakeDialector) QuoteTo(clause.Writer, string)                  {}
+func (d fakeDialector) Explain(string, ...any) string                  { return "" }
 
 func TestPEMDataColumnType(t *testing.T) {
 	tests := []struct {
@@ -17,8 +31,12 @@ func TestPEMDataColumnType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := pemDataColumnType(tt.dialect); got != tt.want {
-			t.Fatalf("pemDataColumnType(%q) = %q, want %q", tt.dialect, got, tt.want)
+		db, err := gorm.Open(fakeDialector(tt.dialect), &gorm.Config{})
+		if err != nil {
+			t.Fatalf("gorm.Open(%q) returned error: %v", tt.dialect, err)
+		}
+		if got := (PEMData{}).GormDBDataType(db, nil); got != tt.want {
+			t.Fatalf("GormDBDataType(%q) = %q, want %q", tt.dialect, got, tt.want)
 		}
 	}
 }
@@ -55,4 +73,3 @@ func TestPEMDataScanAndValue(t *testing.T) {
 		t.Fatalf("Scan(nil) = %#v, want nil", []byte(p))
 	}
 }
-

--- a/storage/model/pem_data_test.go
+++ b/storage/model/pem_data_test.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPEMDataColumnType(t *testing.T) {
+	tests := []struct {
+		dialect string
+		want    string
+	}{
+		{dialect: "mysql", want: "longblob"},
+		{dialect: "postgres", want: "bytea"},
+		{dialect: "sqlite", want: "blob"},
+		{dialect: "other", want: "blob"},
+	}
+
+	for _, tt := range tests {
+		if got := pemDataColumnType(tt.dialect); got != tt.want {
+			t.Fatalf("pemDataColumnType(%q) = %q, want %q", tt.dialect, got, tt.want)
+		}
+	}
+}
+
+func TestPEMDataScanAndValue(t *testing.T) {
+	var p PEMData
+
+	if err := p.Scan([]byte("abc")); err != nil {
+		t.Fatalf("Scan([]byte) returned error: %v", err)
+	}
+	if !bytes.Equal([]byte(p), []byte("abc")) {
+		t.Fatalf("Scan([]byte) = %q, want %q", []byte(p), []byte("abc"))
+	}
+
+	val, err := p.Value()
+	if err != nil {
+		t.Fatalf("Value() returned error: %v", err)
+	}
+	if got, ok := val.([]byte); !ok || !bytes.Equal(got, []byte("abc")) {
+		t.Fatalf("Value() = %#v, want []byte(%q)", val, "abc")
+	}
+
+	if err := p.Scan("xyz"); err != nil {
+		t.Fatalf("Scan(string) returned error: %v", err)
+	}
+	if !bytes.Equal([]byte(p), []byte("xyz")) {
+		t.Fatalf("Scan(string) = %q, want %q", []byte(p), []byte("xyz"))
+	}
+
+	if err := p.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil) returned error: %v", err)
+	}
+	if p != nil {
+		t.Fatalf("Scan(nil) = %#v, want nil", []byte(p))
+	}
+}
+

--- a/storage/model/pem_data_test.go
+++ b/storage/model/pem_data_test.go
@@ -11,13 +11,13 @@ import (
 type fakeDialector string
 
 func (d fakeDialector) Name() string                                   { return string(d) }
-func (d fakeDialector) Initialize(*gorm.DB) error                      { _ = d; return nil }
-func (d fakeDialector) Migrator(*gorm.DB) gorm.Migrator                { _ = d; return nil }
-func (d fakeDialector) DataTypeOf(*schema.Field) string                { _ = d; return "" }
-func (d fakeDialector) DefaultValueOf(*schema.Field) clause.Expression { _ = d; return nil }
-func (d fakeDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  { _ = d }
-func (d fakeDialector) QuoteTo(clause.Writer, string)                  { _ = d }
-func (d fakeDialector) Explain(string, ...any) string                  { _ = d; return "" }
+func (fakeDialector) Initialize(*gorm.DB) error                      { return nil }
+func (fakeDialector) Migrator(*gorm.DB) gorm.Migrator                { return nil }
+func (fakeDialector) DataTypeOf(*schema.Field) string                { return "" }
+func (fakeDialector) DefaultValueOf(*schema.Field) clause.Expression { return nil }
+func (fakeDialector) BindVarTo(clause.Writer, *gorm.Statement, any)  {}
+func (fakeDialector) QuoteTo(clause.Writer, string)                  {}
+func (fakeDialector) Explain(string, ...any) string                  { return "" }
 
 func TestPEMDataColumnType(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Solves https://github.com/go-oidfed/lighthouse/issues/83#issuecomment-4665006605 

Adds a new [`GormDBDataType`](https://gorm.io/docs/data_types.html#GormDataTypeInterface) `selector` to swap the schema for DB based pems to a data type for MySQL and a best guess equivlaents in sqlite for `bytea`. 

After this change, I was able to pass the migration from file-system to db backed pem storage:

```sql
mysql@RDS[]> describe private_keys_federation;
+------------+--------------+------+-----+---------+-------+
| Field      | Type         | Null | Key | Default | Extra |
+------------+--------------+------+-----+---------+-------+
| kid        | varchar(255) | NO   | PRI | NULL    |       |
| pem_data   | longblob     | NO   |     | NULL    |       |
| created_at | bigint       | YES  |     | NULL    |       |
| updated_at | bigint       | YES  |     | NULL    |       |
+------------+--------------+------+-----+---------+-------+
4 rows in set (0.03 sec)
```

```sql
mysql@RDS[]> select kid,created_at, updated_at from private_keys_federation;
+---------------------------------------------+------------+------------+
| kid                                         | created_at | updated_at |
+---------------------------------------------+------------+------------+
| redacted | 1781053088 | 1781056091 |
| federation_ES256                            | 1781053088 | 1781056091 |
| federation_ES256f                           | 1781053088 | 1781056091 |
| redacted | 1781053088 | 1781056091 |
+---------------------------------------------+------------+------------+
4 rows in set (0.02 sec)
```

I also added some test cases, but they seems pretty meh
